### PR TITLE
Fix getSiteUrl to use production domain in Vercel production

### DIFF
--- a/next-js/app/music/lib/helpers.ts
+++ b/next-js/app/music/lib/helpers.ts
@@ -249,15 +249,15 @@ export function formatComposerName(name: string): string {
 /**
  * Gets the full site URL based on the current environment:
  * - In development: http://localhost:3000
- * - On Vercel: Uses VERCEL_URL (preview or production)
- * - Fallback: https://andrewwestling.com
+ * - On Vercel preview: Uses VERCEL_URL
+ * - On Vercel production or fallback: https://andrewwestling.com
  */
 export function getSiteUrl(): string {
   if (process.env.NODE_ENV === "development") {
     return "http://localhost:3000";
   }
 
-  if (process.env.VERCEL_URL) {
+  if (process.env.VERCEL_URL && process.env.VERCEL_ENV !== "production") {
     return `https://${process.env.VERCEL_URL}`;
   }
 


### PR DESCRIPTION
## Summary
Updated the `getSiteUrl()` helper function to correctly use the production domain (`https://andrewwestling.com`) when deployed to Vercel production, rather than using the Vercel URL.

## Key Changes
- Modified the `VERCEL_URL` check to exclude production deployments by adding a condition: `process.env.VERCEL_URL && process.env.VERCEL_ENV !== "production"`
- Updated JSDoc comments to clarify the behavior for different deployment environments

## Implementation Details
The function now properly distinguishes between:
- **Development**: Returns `http://localhost:3000`
- **Vercel preview deployments**: Returns the preview URL from `VERCEL_URL`
- **Vercel production or fallback**: Returns the production domain `https://andrewwestling.com`

This ensures that the production environment always uses the canonical domain instead of the Vercel-generated URL.

https://claude.ai/code/session_01HNmcyHoYXz8EfBNyiv3NhF